### PR TITLE
Don't set the total time when the metadata loads

### DIFF
--- a/GoogleMediaFramework/GMFPlayerViewController.m
+++ b/GoogleMediaFramework/GMFPlayerViewController.m
@@ -161,8 +161,6 @@ NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey =
 
 - (void)playerStateDidChangeToReadyToPlay {
   [_playerView setVideoRenderingView:[_player renderingView]];
-  // TODO(tensafefrogs): Don't set this if an ad is playing / player doesn't have control delegate
-  [_videoPlayerOverlayViewController setTotalTime:[_player totalMediaTime]];
 }
 
 - (void)playerStateDidChangeToPlaying {


### PR DESCRIPTION
Instead let the player update it when playing the content. Fixes issue #6.

@shawnbuso or @gdambrauskas code review, please?
