### PR TITLE
Race condition fix #22

### DIFF
--- a/GoogleMediaFramework/GMFPlayerOverlayViewController.h
+++ b/GoogleMediaFramework/GMFPlayerOverlayViewController.h
@@ -28,12 +28,12 @@
 @interface GMFPlayerOverlayViewController : UIViewController {
  @private
   GMFPlayerOverlayView *_playerOverlayView;
-  __weak NSObject<GMFPlayerControlsViewDelegate> *_delegate;
   GMFPlayerState _playerState;
   BOOL _autoHideEnabled;
   BOOL _playerControlsHidden;
 }
 
+@property(nonatomic, weak) NSObject<GMFPlayerControlsViewDelegate> *delegate;
 @property(nonatomic, weak) id<GMFPlayerOverlayViewControllerDelegate>
     videoPlayerOverlayViewControllerDelegate;
 // Set this to YES when the user is scrubbing. This will cause the spinner to be shown regardless

--- a/GoogleMediaFramework/GMFPlayerViewController.m
+++ b/GoogleMediaFramework/GMFPlayerViewController.m
@@ -247,8 +247,10 @@ NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey =
 
 - (void)videoPlayer:(GMFVideoPlayer *)videoPlayer
     currentTotalTimeDidChangeToTime:(NSTimeInterval)time {
-  [_videoPlayerOverlayViewController setTotalTime:time];
-  [self notifyCurrenTotalTimeDidChange];
+  if([_videoPlayerOverlayViewController.delegate isEqual:self]) {
+    [_videoPlayerOverlayViewController setTotalTime:time];
+    [self notifyCurrenTotalTimeDidChange];
+  }
 }
 
 - (void)videoPlayer:(GMFVideoPlayer *)videoPlayer


### PR DESCRIPTION
Prevents changing the Total Time in a special Race Condition when the PlayerViewController has not the control over its content (when another overlay is displayed)
