### PR TITLE
Remove duration listener when setting PlayerItem

### DIFF
--- a/GoogleMediaFramework/GMFVideoPlayer.m
+++ b/GoogleMediaFramework/GMFVideoPlayer.m
@@ -290,6 +290,7 @@ void GMFAudioRouteChangeListenerCallback(void *inClientData,
 
   // Player observers.
   [_player removeObserver:self forKeyPath:kRateKey];
+  [_player removeObserver:self forKeyPath:kDurationKey];
 
   _player = player;
   if (_player) {


### PR DESCRIPTION
Saw a notice in the logs about a kv observer being left on the player item, now resetting it properly.
