### PR TITLE
Fixed autolayout error

### DIFF
--- a/GoogleMediaFramework/GMFPlayerOverlayViewController.m
+++ b/GoogleMediaFramework/GMFPlayerOverlayViewController.m
@@ -42,8 +42,8 @@ static const NSTimeInterval kAutoHideAnimationDelay = 4.0;
 - (void)loadView {
   CGRect frameRect = CGRectMake(0,
                                 kPaddingTop,
-                                _playerOverlayView.frame.size.width,
-                                _playerOverlayView.frame.size.height);
+                                [UIScreen mainScreen].applicationFrame.size.height - kPaddingTop,
+                                [UIScreen mainScreen].applicationFrame.size.width);
   _playerOverlayView = [[GMFPlayerOverlayView alloc] initWithFrame:frameRect];
   [self setView:_playerOverlayView];
 }


### PR DESCRIPTION
An AutoLayout error occurred every time the video player was launched.

`Unable to simultaneously satisfy constraints.`

I believe it was due to one of the UI elements not having enough space. I believe the problem is in `GMFPlayerOverlayViewController.m`, where the `loadView` function creates a `CGRect` called `frameRect`. When `frameRect` is created, `_playerOverlayView` is `nil`, so `frameRect` ends up with a height of `0` and a width of `0`.

To fix this, I've made it so that `frameRect` takes up the full size of the screen.

The error no longer appears and there don't seem to be any changes in performance/functionality.
