### PR TITLE
Video player and table view combined into one screen

### DIFF
--- a/GoogleMediaFramework/GMFPlayerViewController.m
+++ b/GoogleMediaFramework/GMFPlayerViewController.m
@@ -110,15 +110,7 @@ NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey =
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  if ([self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]) {
-    [self prefersStatusBarHidden];
-    [self performSelector:@selector(setNeedsStatusBarAppearanceUpdate)];
-  } else {
-    // iOS 6
-    [[UIApplication sharedApplication]
-        setStatusBarHidden:YES withAnimation:UIStatusBarAnimationSlide];
-  }
-
+  
   // Listen to tap events that fall through the overlay views
   _tapRecognizer = [[UITapGestureRecognizer alloc]
       initWithTarget:self
@@ -137,11 +129,6 @@ NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey =
 - (void)didTapGestureCapturingView:(UITapGestureRecognizer *)recognizer {
   [_videoPlayerOverlayViewController togglePlayerControlsVisibility];
 }
-
-- (BOOL)prefersStatusBarHidden {
-  return YES;
-}
-
 - (void)restartPlayback {
   [_player replay];
 }

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/xcshareddata/xcschemes/GoogleMediaFrameworkDemo.xcscheme
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/xcshareddata/xcschemes/GoogleMediaFrameworkDemo.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CEB06B3B376646D8AAAF4BFE"
+               BlueprintIdentifier = "88407A13AAA1452593890E0E"
                BuildableName = "libPods.a"
                BlueprintName = "Pods"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo-Info.plist
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo-Info.plist
@@ -28,8 +28,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIStatusBarHidden</key>
-	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDefault</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/VideoListViewController.h
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/VideoListViewController.h
@@ -22,6 +22,8 @@
 @property(nonatomic, strong) UITableView *tableView;
 @property(nonatomic, strong) NSArray *videos;
 @property(nonatomic, strong) GMFIMASDKAdService *adService;
+@property(nonatomic, strong) GMFPlayerViewController *videoPlayerViewController;
+@property(nonatomic) BOOL isVideoPlayerDisplayed;
 
 @end
 


### PR DESCRIPTION
Initially, the demo app worked as follows:

1) A table view listing the videos is displayed.
2) When the user selects a video, then another screen is displayed showing the video player.

Now, the video player and table view are displayed on the same screen. Animations have been added to show and hide the video player. When the screen is rotated to landscape, the video player is made fullscreen.
