### PR TITLE
Clear background color for label media time in iOS 6.1

### DIFF
--- a/GoogleMediaFramework/UILabel+GMFLabels.m
+++ b/GoogleMediaFramework/UILabel+GMFLabels.m
@@ -22,6 +22,8 @@
 
 + (UILabel *)GMF_clearLabelForPlayerControls {
   UILabel *label = [[UILabel alloc] init];
+  label.backgroundColor = [UIColor clearColor];
+  
   UIFont *labelFont = [UIFont fontWithName:@"Helvetica" size:12.0];
   [label GMF_setFont:labelFont andColor:[UIColor whiteColor]];
   return label;


### PR DESCRIPTION
Media time doesn't show in iOS 6.1.

![screen shot 2014-07-21 at 10 04 12 pm](https://cloud.githubusercontent.com/assets/4050656/3645241/78ce4ecc-10e8-11e4-96f5-98f3c9805065.png)
