### PR TITLE
Fixed autolayout warning

### DIFF
--- a/GoogleMediaFramework/GMFPlayerOverlayViewController.m
+++ b/GoogleMediaFramework/GMFPlayerOverlayViewController.m
@@ -40,10 +40,13 @@ static const NSTimeInterval kAutoHideAnimationDelay = 4.0;
 }
 
 - (void)loadView {
+  CGRect screenRect = [[UIScreen mainScreen] bounds];
+  CGFloat screenWidth = screenRect.size.width;
+  CGFloat screenHeight = screenRect.size.height;
   CGRect frameRect = CGRectMake(0,
                                 kPaddingTop,
-                                _playerOverlayView.frame.size.width,
-                                _playerOverlayView.frame.size.height);
+                                screenWidth,
+                                screenHeight);
   _playerOverlayView = [[GMFPlayerOverlayView alloc] initWithFrame:frameRect];
   [self setView:_playerOverlayView];
 }


### PR DESCRIPTION
There was an autolayout warning which occurred in the overlay view because it couldn't satisfy all its layout constraints.

This occurred because when the overlay view was first created, it was given dimensions of (_playerOverlayView.frame.size.width and _playerOverlayView.frame.size.height), which were always (0, 0) when the view was instantiated. The overlay view was never actually displayed with the (0, 0) dimensions, but instead was resized by the GMFPlayerView to be the correct size. However, since we initialized the overlay view with (0, 0), it created a warning because it didn't have enough room to layout its UI elements.

To avoid this, we initialize the overlay view with dimensions (screenWidth, screenHeight). This way, it has enough room to layout its UI elements and therefore does not cause a warning. And as usual, the GMFPlayerView can resize the overlay view to be the correct size when it comes time to display it.
