### PR TITLE
Enabling Custom PlayerControl overlays

### DIFF
--- a/GoogleMediaFramework/GMFPlayerControlsProtocol.h
+++ b/GoogleMediaFramework/GMFPlayerControlsProtocol.h
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "GMFPlayerControlsView.h"
 
 @protocol GMFPlayerControlsProtocol<NSObject>
 
+@property(nonatomic, weak) id<GMFPlayerControlsViewDelegate> delegate;
+
 // These are all mutually exclusive. E.g. calling showPlayButton hides all the
 // other views and shows the play button. Only one can be shown at a time.
+
 - (void)showPlayButton;
 - (void)showPauseButton;
 - (void)showReplayButton;
@@ -28,5 +32,16 @@
 
 - (void)setTotalTime:(NSTimeInterval)totalTime;
 - (void)setMediaTime:(NSTimeInterval)mediaTime;
+
+
+@optional
+
+- (void)addActionButtonWithImage:(UIImage *)image
+                            name:(NSString *)name
+                          target:(id)target
+                        selector:(SEL)selector;
+- (void)applyControlTintColor:(UIColor *)color;
+- (void)setVideoTitle:(NSString *)videoTitle;
+- (void)setLogoImage:(UIImage *)logoImage;
 
 @end

--- a/GoogleMediaFramework/GMFPlayerControlsView.m
+++ b/GoogleMediaFramework/GMFPlayerControlsView.m
@@ -196,9 +196,9 @@ static const CGFloat kGMFBarPaddingX = 4;
   NSInteger minutes = (durationSecondsRounded / 60) % 60;
   NSInteger hours = durationSecondsRounded / 3600;
   if (hours) {
-    return [NSString stringWithFormat:@"%d:%02d:%02d", hours, minutes, seconds];
+    return [NSString stringWithFormat:@"%ld:%02ld:%02ld", (long) hours, (long) minutes, (long) seconds];
   } else {
-    return [NSString stringWithFormat:@"%d:%02d", minutes, seconds];
+    return [NSString stringWithFormat:@"%ld:%02ld", (long) minutes, (long) seconds];
   }
 }
 

--- a/GoogleMediaFramework/GMFPlayerOverlayView.h
+++ b/GoogleMediaFramework/GMFPlayerOverlayView.h
@@ -30,12 +30,12 @@ typedef enum CurrentPlayPauseReplayIcon {
   REPLAY
 } CurrentPlayPauseReplayIcon;
 
-@property(nonatomic, weak) id<GMFPlayerControlsViewDelegate> delegate;
-
 @property(nonatomic, readonly) GMFPlayerControlsView *playerControlsView;
 @property(nonatomic, readonly) GMFTopBarView *topBarView;
 @property(nonatomic, strong) UIColor *tintedBackgroundColor;
 @property(nonatomic, strong) UIColor *playPauseResetButtonBackgroundColor;
+@property(nonatomic, weak) id<GMFPlayerControlsViewDelegate> delegate;
+
 
 // Show/hide the loading spinner
 - (void)showSpinner;

--- a/GoogleMediaFramework/GMFPlayerOverlayView.m
+++ b/GoogleMediaFramework/GMFPlayerOverlayView.m
@@ -307,13 +307,13 @@
   // Determine which icon the play/pause/replay button is showing and respond appropriately.
   switch (_currentPlayPauseReplayIcon) {
     case PLAY:
-      [_delegate didPressPlay];
+      [self.delegate didPressPlay];
       break;
     case REPLAY:
-      [_delegate didPressReplay];
+      [self.delegate didPressReplay];
       break;
     case PAUSE:
-      [_delegate didPressPause];
+      [self.delegate didPressPause];
       break;
     default:
       break;

--- a/GoogleMediaFramework/GMFPlayerOverlayViewController.h
+++ b/GoogleMediaFramework/GMFPlayerOverlayViewController.h
@@ -25,7 +25,26 @@
 - (void)playerControlsDidHide;
 @end
 
-@interface GMFPlayerOverlayViewController : UIViewController {
+
+@protocol GMFPlayerOverlayViewControllerProtocol <NSObject>
+
+@property (nonatomic, weak) id<GMFPlayerOverlayViewControllerDelegate> delegate;
+@property (nonatomic, strong) UIView<GMFPlayerControlsProtocol> *playerOverlayView;
+// Set this to YES when the user is scrubbing. This will cause the spinner to be shown regardless
+// of state.
+@property (nonatomic) BOOL userScrubbing;
+
+- (void) showPlayerControlsAnimated:(BOOL) animated;
+- (void) hidePlayerControlsAnimated:(BOOL) animated;
+- (void) setTotalTime:(NSTimeInterval) totalTime;
+- (void) setMediaTime:(NSTimeInterval) mediaTime;
+- (void) togglePlayerControlsVisibility;
+- (void) playerStateDidChangeToState:(GMFPlayerState) toState;
+- (void) reset;
+
+@end
+
+@interface GMFPlayerOverlayViewController : UIViewController <GMFPlayerOverlayViewControllerProtocol> {
  @private
   GMFPlayerOverlayView *_playerOverlayView;
   GMFPlayerState _playerState;
@@ -33,35 +52,20 @@
   BOOL _playerControlsHidden;
 }
 
-@property(nonatomic, weak) NSObject<GMFPlayerControlsViewDelegate> *delegate;
+@property (nonatomic, weak) id<GMFPlayerOverlayViewControllerDelegate> delegate;
+@property (nonatomic, strong) UIView<GMFPlayerControlsProtocol> *playerOverlayView;
+@property (nonatomic) BOOL userScrubbing;
 @property(nonatomic, weak) id<GMFPlayerOverlayViewControllerDelegate>
     videoPlayerOverlayViewControllerDelegate;
-// Set this to YES when the user is scrubbing. This will cause the spinner to be shown regardless
-// of state.
-@property(nonatomic, assign, getter=isUserScrubbing) BOOL userScrubbing;
-
-- (void)setDelegate:(NSObject<GMFPlayerControlsViewDelegate> *)delegate;
 
 - (void)playerStateDidChangeToState:(GMFPlayerState)toState;
-
-- (void)showPlayerControlsAnimated:(BOOL)animated;
-- (void)hidePlayerControlsAnimated:(BOOL)animated;
 
 - (void)playerControlsDidHide;
 - (void)playerControlsWillHide;
 - (void)playerControlsDidShow;
 - (void)playerControlsWillShow;
 
-- (void)setTotalTime:(NSTimeInterval)totalTime;
-- (void)setMediaTime:(NSTimeInterval)mediaTime;
-
-- (GMFPlayerOverlayView *)playerOverlayView;
-
 - (GMFPlayerControlsView *)playerControlsView;
-
-- (void)togglePlayerControlsVisibility;
-
-- (void)reset;
 
 - (void)resetAutoHideTimer;
 

--- a/GoogleMediaFramework/GMFPlayerOverlayViewController.m
+++ b/GoogleMediaFramework/GMFPlayerOverlayViewController.m
@@ -50,12 +50,12 @@ static const NSTimeInterval kAutoHideAnimationDelay = 4.0;
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [_playerOverlayView setDelegate:_delegate];
+  [self.playerOverlayView setDelegate:self.delegate];
   [_playerOverlayView showSpinner];
   [self playerStateDidChangeToState:_playerState];
 }
 
-- (void)setDelegate:(NSObject<GMFPlayerControlsViewDelegate> *)delegate {
+- (void)setDelegate:(id <GMFPlayerOverlayViewControllerDelegate>) delegate {
   // Store delegate in case the view isn't loaded yet.
   _delegate = delegate;
   [_playerOverlayView setDelegate:delegate];
@@ -68,7 +68,7 @@ static const NSTimeInterval kAutoHideAnimationDelay = 4.0;
 - (void)setUserScrubbing:(BOOL)userScrubbing {
   _userScrubbing = userScrubbing;
   [self updateAutoHideEnabled];
-  if (_userScrubbing) {
+  if (self.userScrubbing) {
     [_playerOverlayView showSpinner];
   } else {
     // Refresh the state so the correct button is shown.
@@ -79,7 +79,7 @@ static const NSTimeInterval kAutoHideAnimationDelay = 4.0;
 - (void)playerStateDidChangeToState:(GMFPlayerState)toState {
   _playerState = toState;
   [self updatePlayerBarViewButtonWithState:toState];
-  if (_userScrubbing) {
+  if (self.userScrubbing) {
     return;
   }
   [self updateAutoHideEnabled];
@@ -186,7 +186,7 @@ static const NSTimeInterval kAutoHideAnimationDelay = 4.0;
 }
 
 - (void)updateAutoHideEnabled {
-  BOOL enabled = (_playerState == kGMFPlayerStatePlaying) && ![self isUserScrubbing];
+  BOOL enabled = (_playerState == kGMFPlayerStatePlaying) && !self.userScrubbing;
   if (_autoHideEnabled != enabled) {
     _autoHideEnabled = enabled;
     if (!enabled) {

--- a/GoogleMediaFramework/GMFPlayerView.h
+++ b/GoogleMediaFramework/GMFPlayerView.h
@@ -18,7 +18,7 @@
 
 @interface GMFPlayerView : UIView {
  @private
-  GMFPlayerOverlayView *_overlayView;
+  UIView<GMFPlayerControlsProtocol> *_overlayView;
 }
 
 @property(nonatomic, weak) UIView *aboveRenderingView;
@@ -37,7 +37,7 @@
 
 - (void)setAboveRenderingView:(UIView *)aboveRenderingView;
 
-- (void)setOverlayView:(GMFPlayerOverlayView *)overlayView;
+- (void)setOverlayView:(UIView<GMFPlayerControlsProtocol> *)overlayView;
 
 @end
 

--- a/GoogleMediaFramework/GMFPlayerView.m
+++ b/GoogleMediaFramework/GMFPlayerView.m
@@ -61,7 +61,7 @@
   [self setNeedsLayout];
 }
 
-- (void)setOverlayView:(GMFPlayerOverlayView *)overlayView {
+- (void)setOverlayView:(UIView<GMFPlayerControlsProtocol> *)overlayView {
   [_overlayView removeFromSuperview];
   _overlayView = overlayView;
   if (_overlayView) {

--- a/GoogleMediaFramework/GMFPlayerViewController.h
+++ b/GoogleMediaFramework/GMFPlayerViewController.h
@@ -29,6 +29,7 @@ extern NSString * const kGMFPlayerStateWillChangeToFinishedNotification;
 extern NSString * const kGMFPlayerPlaybackDidFinishReasonUserInfoKey;
 extern NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey;
 
+
 @interface GMFPlayerViewController : UIViewController<GMFVideoPlayerDelegate,
                                                       GMFPlayerOverlayViewControllerDelegate,
                                                       GMFPlayerControlsViewDelegate,
@@ -38,6 +39,7 @@ extern NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey;
 }
 
 @property(nonatomic, readonly) GMFPlayerView *playerView;
+@property(nonatomic, strong) UIViewController <GMFPlayerOverlayViewControllerProtocol> *videoPlayerOverlayViewController;
 
 @property(nonatomic, weak) GMFAdService *adService;
 
@@ -82,7 +84,7 @@ extern NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey;
 
 - (void)setDefaultVideoPlayerOverlayDelegate;
 
-- (GMFPlayerOverlayView *)playerOverlayView;
+- (UIView<GMFPlayerControlsProtocol> *)playerOverlayView;
 
 @end
 


### PR DESCRIPTION
I extracted some functions from `GMFPlayerOverlayViewController` into a Protocol and changed all Variables to use `UIViewController<GMFPLayerOverlayViewControllerProtocol>`  instead of `GMFPlayerOverlayViewController`.
Also all usages of `GMFPlayerOverlayView` are now referencing Objects of Type `UIView<GMFPlayerControlsProtocol>` 
This Allows users to use custom Overlay controllers and views.

If no custom overlay controller is set before loading the standard is used.
