### PR TITLE
Call content complete when player is killed

### DIFF
--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.m
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.m
@@ -57,12 +57,7 @@
 // Listen to playbackWill finish in order to play postrolls if needed before the player ends.
 // The GMFVideoPlayerSDK subscribes to this notification automatically.
 - (void)playbackWillFinish:(NSNotification *)notification {
-  int finishReason = [[[notification userInfo]
-      objectForKey:kGMFPlayerPlaybackWillFinishReasonUserInfoKey] intValue];
-  if (finishReason == GMFPlayerFinishReasonPlaybackEnded) {
-    // Playback reached the end of the video, notify AdsManager in case there are postrolls.
-    [self.adsLoader contentComplete];
-  }
+  [self.adsLoader contentComplete];
 }
 
 // Destroy adsManager when user exits the player


### PR DESCRIPTION
I noticed that sometimes ads didn't play. For instance, clicking the "Skippable preroll" video, then switching to another video, and then returning to "Skippable preroll" would not show a preroll at all.

The reason seems to be that the IMA SDK expects us to call contentComplete in the adsLoader. Initially, we were calling this method only if the playback ended. Now, we are calling it whenever the video player is killed when an ad is playing. This way, we can play the video again without worrying that the ad won't be displayed.
