### PR TITLE
Refactored setAboveRenderingView to fix typo

### DIFF
--- a/GoogleMediaFramework/GMFPlayerViewController.h
+++ b/GoogleMediaFramework/GMFPlayerViewController.h
@@ -78,7 +78,7 @@ extern NSString * const kGMFPlayerPlaybackWillFinishReasonUserInfoKey;
 
 - (void)registerAdService:(GMFAdService *)adService;
 
-- (void)setABoveRenderingView:(UIView *)view;
+- (void)setAboveRenderingView:(UIView *)view;
 
 - (void)setControlsVisibility:(BOOL)visible animated:(BOOL)animated;
 

--- a/GoogleMediaFramework/GMFPlayerViewController.m
+++ b/GoogleMediaFramework/GMFPlayerViewController.m
@@ -98,7 +98,7 @@ NSString *const kActionButtonSelectorKey = @"kActionButtonSelectorKey";
   [_player pause];
 }
 
-- (void)setABoveRenderingView:(UIView *)view {
+- (void)setAboveRenderingView:(UIView *)view {
   [_playerView setAboveRenderingView:view];
   [view addGestureRecognizer:[[UITapGestureRecognizer alloc]
                               initWithTarget:self

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.m
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.m
@@ -37,7 +37,7 @@
   // Thus, we create one and add it to the video player.
   if (self.videoPlayerController.playerView.aboveRenderingView == nil) {
     UIView *view = [[UIView alloc] initWithFrame:self.videoPlayerController.view.bounds];
-    [self.videoPlayerController setABoveRenderingView:view];
+    [self.videoPlayerController setAboveRenderingView:view];
     self.adDisplayContainer = [[IMAAdDisplayContainer alloc] initWithAdContainer:view
                                                                   companionSlots:nil];
   }


### PR DESCRIPTION
There was a method called `setABoveRenderingView` (notice that the "B" is capitalized), so I refactored it to be `setAboveRenderingView`
