### PR TITLE
Update podspec to 6.1, migrate to XCTest, fix project config for new Coc...

### DIFF
--- a/GoogleMediaFramework.podspec
+++ b/GoogleMediaFramework.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = "Google, Inc."
   s.source       = { :git => "https://github.com/googleads/google-media-framework-ios.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '6.0'
+  s.platform     = :ios, '6.1'
   s.requires_arc = true
 
   s.source_files = 'GoogleMediaFramework'

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/project.pbxproj
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		4CAD3F7D17BD4703008C6D28 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 4CAD3F7C17BD4703008C6D28 /* Default.png */; };
 		4CAD3F7F17BD4703008C6D28 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4CAD3F7E17BD4703008C6D28 /* Default@2x.png */; };
 		4CAD3F8117BD4703008C6D28 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4CAD3F8017BD4703008C6D28 /* Default-568h@2x.png */; };
-		4CAD3F9217BD4703008C6D28 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CAD3F9117BD4703008C6D28 /* SenTestingKit.framework */; };
 		4CAD3F9317BD4704008C6D28 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CAD3F6A17BD4703008C6D28 /* UIKit.framework */; };
 		4CAD3F9417BD4704008C6D28 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CAD3F6C17BD4703008C6D28 /* Foundation.framework */; };
 		4CAD3F9C17BD4704008C6D28 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4CAD3F9A17BD4704008C6D28 /* InfoPlist.strings */; };
@@ -37,6 +36,7 @@
 		A8A054BB17E270A50035D08D /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8A054B617E270A50035D08D /* CoreFoundation.framework */; };
 		A8A054BC17E270A50035D08D /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8A054B717E270A50035D08D /* MessageUI.framework */; };
 		A8A054BD17E270A50035D08D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8A054B817E270A50035D08D /* QuartzCore.framework */; };
+		C1E0520A22C74461D02DEF62 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D64E0D2ECC1547E581F50A56 /* libPods.a */; };
 		E8E83A6A2D044DFF96AF06E1 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D64E0D2ECC1547E581F50A56 /* libPods.a */; };
 /* End PBXBuildFile section */
 
@@ -63,7 +63,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		4B7B8DF517044E339E38FF76 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 		4C00AF3417F2081700167389 /* GMFIMASDKAdService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = GMFIMASDKAdService.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		4C00AF3517F2081700167389 /* GMFIMASDKAdService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = GMFIMASDKAdService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4C5BB60F17D13D86003D9E20 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -83,7 +82,6 @@
 		4CAD3F7E17BD4703008C6D28 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
 		4CAD3F8017BD4703008C6D28 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		4CAD3F9017BD4703008C6D28 /* GoogleMediaFrameworkDemoTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoogleMediaFrameworkDemoTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		4CAD3F9117BD4703008C6D28 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		4CAD3F9917BD4704008C6D28 /* GoogleMediaFrameworkTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleMediaFrameworkTests-Info.plist"; sourceTree = "<group>"; };
 		4CAD3F9B17BD4704008C6D28 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		4CAD3F9D17BD4704008C6D28 /* GoogleMediaFrameworkDemoTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GoogleMediaFrameworkDemoTests.h; sourceTree = "<group>"; };
@@ -94,6 +92,7 @@
 		4CD7815117EC9E9B00930F92 /* VideoListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = VideoListViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4CF77DE818567DAD00F98F76 /* VideoData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoData.h; sourceTree = "<group>"; };
 		4CF77DE918567DAD00F98F76 /* VideoData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VideoData.m; sourceTree = "<group>"; };
+		7344A49C086478D343BFE475 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		73BCC5B9199BE2E200B65504 /* Gmf-Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Gmf-Icon.png"; sourceTree = "<group>"; };
 		8758392B1989716200DDD0D2 /* Delete-Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Delete-Icon.png"; sourceTree = "<group>"; };
 		8758392C1989716200DDD0D2 /* Favorite-Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Favorite-Icon.png"; sourceTree = "<group>"; };
@@ -104,6 +103,7 @@
 		A8A054B817E270A50035D08D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		A8A054B917E270A50035D08D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		D64E0D2ECC1547E581F50A56 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6ECCA408889EA03EBBB5A91 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,15 +130,24 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4CAD3F9217BD4703008C6D28 /* SenTestingKit.framework in Frameworks */,
 				4CAD3F9317BD4704008C6D28 /* UIKit.framework in Frameworks */,
 				4CAD3F9417BD4704008C6D28 /* Foundation.framework in Frameworks */,
+				C1E0520A22C74461D02DEF62 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		033BF432EF1BA7820BDDC544 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7344A49C086478D343BFE475 /* Pods.debug.xcconfig */,
+				D6ECCA408889EA03EBBB5A91 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		4CAD3F5E17BD4703008C6D28 = {
 			isa = PBXGroup;
 			children = (
@@ -146,7 +155,7 @@
 				4CAD3F9717BD4704008C6D28 /* GoogleMediaFrameworkDemoTests */,
 				4CAD3F6917BD4703008C6D28 /* Frameworks */,
 				4CAD3F6817BD4703008C6D28 /* Products */,
-				4B7B8DF517044E339E38FF76 /* Pods.xcconfig */,
+				033BF432EF1BA7820BDDC544 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -173,7 +182,6 @@
 				4CAD3F6A17BD4703008C6D28 /* UIKit.framework */,
 				4CAD3F6C17BD4703008C6D28 /* Foundation.framework */,
 				4CAD3F6E17BD4703008C6D28 /* CoreGraphics.framework */,
-				4CAD3F9117BD4703008C6D28 /* SenTestingKit.framework */,
 				D64E0D2ECC1547E581F50A56 /* libPods.a */,
 			);
 			name = Frameworks;
@@ -262,10 +270,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4CAD3FA517BD4704008C6D28 /* Build configuration list for PBXNativeTarget "GoogleMediaFrameworkDemoTests" */;
 			buildPhases = (
+				54F1D64544B905FFAC4BA68C /* Check Pods Manifest.lock */,
 				4CAD3F8B17BD4703008C6D28 /* Sources */,
 				4CAD3F8C17BD4703008C6D28 /* Frameworks */,
 				4CAD3F8D17BD4703008C6D28 /* Resources */,
 				4CAD3F8E17BD4703008C6D28 /* Run Script */,
+				14D8903475E92628C1CE57EC /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -275,7 +285,7 @@
 			name = GoogleMediaFrameworkDemoTests;
 			productName = GoogleMediaFrameworkDemoTests;
 			productReference = 4CAD3F9017BD4703008C6D28 /* GoogleMediaFrameworkDemoTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -284,7 +294,8 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = GMF;
-				LastUpgradeCheck = 0500;
+				LastTestingUpgradeCheck = 0600;
+				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Google;
 			};
 			buildConfigurationList = 4CAD3F6217BD4703008C6D28 /* Build configuration list for PBXProject "GoogleMediaFrameworkDemo" */;
@@ -332,6 +343,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		14D8903475E92628C1CE57EC /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		4CAD3F8E17BD4703008C6D28 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -346,6 +372,21 @@
 			shellPath = /bin/sh;
 			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
 		};
+		54F1D64544B905FFAC4BA68C /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		771FE8B597914A5BB20F7EA9 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -358,7 +399,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B43CA9D051C344D89EAEDD1C /* Check Pods Manifest.lock */ = {
@@ -434,7 +475,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -458,7 +498,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -468,7 +509,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -485,7 +525,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				OTHER_LDFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -494,9 +536,8 @@
 		};
 		4CAD3FA317BD4704008C6D28 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4B7B8DF517044E339E38FF76 /* Pods.xcconfig */;
+			baseConfigurationReference = 7344A49C086478D343BFE475 /* Pods.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -505,10 +546,7 @@
 				INFOPLIST_FILE = "GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo-Info.plist";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lGoogleIMA3",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "B218B3A1-E07D-44F2-AA69-6739FC0F6D19";
 				WRAPPER_EXTENSION = app;
@@ -517,9 +555,8 @@
 		};
 		4CAD3FA417BD4704008C6D28 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4B7B8DF517044E339E38FF76 /* Pods.xcconfig */;
+			baseConfigurationReference = D6ECCA408889EA03EBBB5A91 /* Pods.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -528,10 +565,7 @@
 				INFOPLIST_FILE = "GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo-Info.plist";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lGoogleIMA3",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "B218B3A1-E07D-44F2-AA69-6739FC0F6D19";
 				WRAPPER_EXTENSION = app;
@@ -540,40 +574,42 @@
 		};
 		4CAD3FA617BD4704008C6D28 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4B7B8DF517044E339E38FF76 /* Pods.xcconfig */;
+			baseConfigurationReference = 7344A49C086478D343BFE475 /* Pods.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GoogleMediaFrameworkDemo.app/GoogleMediaFrameworkDemo";
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo-Prefix.pch";
 				INFOPLIST_FILE = "GoogleMediaFrameworkTests/GoogleMediaFrameworkTests-Info.plist";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
 		4CAD3FA717BD4704008C6D28 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4B7B8DF517044E339E38FF76 /* Pods.xcconfig */;
+			baseConfigurationReference = D6ECCA408889EA03EBBB5A91 /* Pods.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GoogleMediaFrameworkDemo.app/GoogleMediaFrameworkDemo";
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo-Prefix.pch";
 				INFOPLIST_FILE = "GoogleMediaFrameworkTests/GoogleMediaFrameworkTests-Info.plist";
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/xcshareddata/xcschemes/GoogleMediaFrameworkDemo.xcscheme
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/xcshareddata/xcschemes/GoogleMediaFrameworkDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7AA55E5E564A4BCE84DE1FCE"
+               BlueprintIdentifier = "F2EA1CCC9C7885B013598134"
                BuildableName = "libPods.a"
                BlueprintName = "Pods"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkTests/GoogleMediaFrameworkDemoTests.h
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkTests/GoogleMediaFrameworkDemoTests.h
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import "GMFVideoPlayer.h"
 
-@interface GoogleMediaFrameworkDemoTests : SenTestCase<GMFVideoPlayerDelegate>
+@interface GoogleMediaFrameworkDemoTests : XCTestCase<GMFVideoPlayerDelegate>
 
 + (NSString *)stringWithState:(GMFPlayerState)state;
 

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkTests/GoogleMediaFrameworkDemoTests.m
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkTests/GoogleMediaFrameworkDemoTests.m
@@ -79,7 +79,7 @@ int DEFAULT_TIMEOUT = 10;
   [_player replay];
   [self waitForState:kGMFPlayerStateSeeking];
   [self waitForState:kGMFPlayerStatePlaying];
-  STAssertTrue([_player currentMediaTime] < 0.25,
+  XCTAssertTrue([_player currentMediaTime] < 0.25,
                @"Player media time should be near the beginning of the movie, but it is %f.",
                [_player currentMediaTime]);
   [self assertPlaybackDoesProgress];
@@ -112,7 +112,7 @@ int DEFAULT_TIMEOUT = 10;
   [_player seekToTime:-totalMediaTime];
   [self waitForState:kGMFPlayerStateSeeking];
   [self waitForState:kGMFPlayerStatePaused];
-  STAssertTrue([_player currentMediaTime] == 0,
+  XCTAssertTrue([_player currentMediaTime] == 0,
                @"Current media time should be 0 for seeks before the beginning.");
   
   // Seek after the end.
@@ -160,7 +160,7 @@ int DEFAULT_TIMEOUT = 10;
 }
 
 - (void)assertNoOtherStateChange {
-  STAssertFalse(_eventList.count, @"Unexpected events %@", _eventList);
+  XCTAssertFalse(_eventList.count, @"Unexpected events %@", _eventList);
 }
 
 - (void) waitForState:(GMFPlayerState)state {
@@ -168,7 +168,7 @@ int DEFAULT_TIMEOUT = 10;
 }
 
 - (void) waitForState:(GMFPlayerState)state withTimeout:(NSInteger)timeout {
-  STAssertTrue(
+  XCTAssertTrue(
     WaitFor(
       ^BOOL {
           return ([_eventList count] > 0 && _eventList[0] == [NSNumber numberWithInt:state]);
@@ -202,7 +202,7 @@ BOOL WaitFor(BOOL (^block)(void), NSTimeInterval seconds) {
   NSTimeInterval startMediaTime = [_player currentMediaTime];
   [self waitForTimeInterval:1];
   NSTimeInterval endMediaTime = [_player currentMediaTime];
-  STAssertTrue(startMediaTime != endMediaTime,
+  XCTAssertTrue(startMediaTime != endMediaTime,
                @"Playback progressed when it was not expected to");
 }
 
@@ -210,7 +210,7 @@ BOOL WaitFor(BOOL (^block)(void), NSTimeInterval seconds) {
   NSTimeInterval startMediaTime = [_player currentMediaTime];
   [self waitForTimeInterval:1];
   NSTimeInterval endMediaTime = [_player currentMediaTime];
-  STAssertTrue(startMediaTime == endMediaTime,
+  XCTAssertTrue(startMediaTime == endMediaTime,
                @"Playback progressed when it was not expected to");
 }
 
@@ -235,6 +235,11 @@ BOOL WaitFor(BOOL (^block)(void), NSTimeInterval seconds) {
 
 - (void)videoPlayer:(GMFVideoPlayer *)videoPlayer
     bufferedMediaTimeDidChangeToTime:(NSTimeInterval)time {
+  // no-op
+}
+
+- (void)videoPlayer:(GMFVideoPlayer *)videoPlayer
+    currentTotalTimeDidChangeToTime:(NSTimeInterval)time {
   // no-op
 }
 

--- a/GoogleMediaFrameworkDemo/Podfile
+++ b/GoogleMediaFrameworkDemo/Podfile
@@ -1,6 +1,7 @@
-platform :ios, "6.0"
+source 'https://github.com/CocoaPods/Specs.git'
+
+platform :ios, "6.1"
 
 pod "GoogleMediaFramework", :path => "../"
 # Demo app shows how to integrate with the Google IMA SDK, but this is optional.
 pod "GoogleAds-IMA-iOS-SDK", "~> 3.0.beta"
-


### PR DESCRIPTION
Update podspec to 6.1, migrate to XCTest, fix project config for new Cocoapods version.

This is basically a cleanup change: The travis build started failing and I believe it was due to some Cocoapods changes. The config changes are to fix the new Cocoapods requirements, and while testing that I found that the unit test was out of date, so fixed that, and then had to convert it to XCTest since SenTestKit is apparently deprecated.

@hariharsubramanyam any chance you have time to take a look at this? (no rush!)
