### PR TITLE
Updating for iOS 9

### DIFF
--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/xcshareddata/xcschemes/GoogleMediaFrameworkDemo.xcscheme
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo.xcodeproj/xcshareddata/xcschemes/GoogleMediaFrameworkDemo.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F2EA1CCC9C7885B013598134"
+               BlueprintIdentifier = "0D991E7647338654F8B2E4C7467E824B"
                BuildableName = "libPods.a"
                BlueprintName = "Pods"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -37,17 +37,17 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CAD3F8F17BD4703008C6D28"
-               BuildableName = "GoogleMediaFrameworkDemoTests.octest"
+               BuildableName = "GoogleMediaFrameworkDemoTests.xctest"
                BlueprintName = "GoogleMediaFrameworkDemoTests"
                ReferencedContainer = "container:GoogleMediaFrameworkDemo.xcodeproj">
             </BuildableReference>
@@ -62,17 +62,21 @@
             ReferencedContainer = "container:GoogleMediaFrameworkDemo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CAD3F6617BD4703008C6D28"
@@ -85,12 +89,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CAD3F6617BD4703008C6D28"

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.h
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.h
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 #import <GoogleMediaFramework/GoogleMediaFramework.h>
-#import <IMAAdsLoader.h>
-#import <IMAAdsManager.h>
+#import <GoogleInteractiveMediaAds/GoogleInteractiveMediaAds.h>
 
 @interface GMFIMASDKAdService : GMFAdService<IMAAdsLoaderDelegate,
                                              IMAAdsManagerDelegate,

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.m
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/GMFIMASDKAdService.m
@@ -27,12 +27,15 @@
 
 // Designated initializer
 - (instancetype)initWithGMFVideoPlayer:(GMFPlayerViewController *)videoPlayerController {
-  return [super initWithGMFVideoPlayer:videoPlayerController];
+  self = [super initWithGMFVideoPlayer:videoPlayerController];
+  if (self) {
+    self.adsLoader = [[IMAAdsLoader alloc] initWithSettings:[self createIMASettings]];
+    self.adsLoader.delegate = self;
+  }
+  return self;
 }
 
 - (void)requestAdsWithRequest:(NSString *)request {
-  [self createAdsLoader];
-  
   // If there is no view above the rendering view, then there is no ads display container.
   // Thus, we create one and add it to the video player.
   if (self.videoPlayerController.playerView.aboveRenderingView == nil) {
@@ -46,18 +49,13 @@
                                                    adDisplayContainer:self.adDisplayContainer
                                                           userContext:nil];
 
-  [_adsLoader requestAdsWithRequest:adsRequest];
+  [self.adsLoader requestAdsWithRequest:adsRequest];
 }
 
 - (IMASettings *)createIMASettings {
   IMASettings *settings = [[IMASettings alloc] init];
   settings.language = @"en";
   return settings;
-}
-
-- (void)createAdsLoader {
-  self.adsLoader = [[IMAAdsLoader alloc] initWithSettings:[self createIMASettings]];
-  self.adsLoader.delegate = self;
 }
 
 #pragma mark GMFVideoPlayerViewController notification handlers
@@ -279,6 +277,9 @@
     case kIMAAdEvent_RESUME:
       // Ad resumed.
       return @"Ad Resumed";
+    case kIMAAdEvent_TAPPED:
+      // Ad Tapped.
+      return @"Ad Tapped";
     case kIMAAdEvent_THIRD_QUARTILE:
       // Third quartile of a linear ad was reached.
       return @"Third quartile reached";
@@ -286,7 +287,7 @@
       // Ad has started.
       return @"Ad Started";
     default:
-      return @"Invalid Error type";
+      return @"Invalid Event type";
   }
 }
 

--- a/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/VideoListViewController.m
+++ b/GoogleMediaFrameworkDemo/GoogleMediaFrameworkDemo/VideoListViewController.m
@@ -297,24 +297,33 @@
 
 // Populates the videos array with our sample content..
 - (void)populateVideosArray {
+  NSString *contentURL = @"https://s0.2mdn.net/instream/videoplayer/media/android.mp4";
   if ([_videos count] == 0) {
     _videos = @[
-      [[VideoData alloc] initWithVideoURL:@"http://googleimadev-vh.akamaihd.net/i/big_buck_bunny/bbb-,480p,720p,1080p,.mov.csmil/master.m3u8"
+      [[VideoData alloc] initWithVideoURL:contentURL
                                     title:@"Video with no ads"
                                   summary:@""
                                  adTagURL:nil],
-      [[VideoData alloc] initWithVideoURL:@"http://googleimadev-vh.akamaihd.net/i/big_buck_bunny/bbb-,480p,720p,1080p,.mov.csmil/master.m3u8"
+      [[VideoData alloc] initWithVideoURL:contentURL
                                     title:@"Skippable preroll"
                                   summary:@""
-                                 adTagURL:@"http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fgmf_demo&ciu_szs&impl=s&gdfp_req=1&env=vp&output=xml_vast3&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=gmf_format%3Dskip"],
-      [[VideoData alloc] initWithVideoURL:@"http://googleimadev-vh.akamaihd.net/i/big_buck_bunny/bbb-,480p,720p,1080p,.mov.csmil/master.m3u8"
+                                 adTagURL:@"http://pubads.g.doubleclick.net/gampad/ads?sz=640x360&iu=/6062/iab_vast_samples/skippable&"
+       @"ciu_szs=300x250,728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&"
+       @"url=[referrer_url]&correlator=[timestamp]"],
+      [[VideoData alloc] initWithVideoURL:contentURL
                                     title:@"Unskippable preroll"
                                   summary:@""
-                                 adTagURL:@"http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fgmf_demo&ciu_szs&impl=s&gdfp_req=1&env=vp&output=xml_vast3&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=gmf_format%3Dstd"],
-      [[VideoData alloc] initWithVideoURL:@"http://googleimadev-vh.akamaihd.net/i/big_buck_bunny/bbb-,480p,720p,1080p,.mov.csmil/master.m3u8"
+                                 adTagURL:@"http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&"
+       @"iu=%2F6062%2Fhanna_MA_group%2Fvideo_comp_app&ciu_szs=&impl=s&gdfp_req=1&env=vp&"
+       @"output=xml_vast2&unviewed_position_start=1&m_ast=vast&url=[referrer_url]&"
+       @"correlator=[timestamp]"],
+      [[VideoData alloc] initWithVideoURL:contentURL
                                     title:@"Adrules (Preroll and ad breaks at 5s, 10s, 15s)"
                                   summary:@""
-                                 adTagURL:@"http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fgmf_demo&ciu_szs&impl=s&gdfp_req=1&env=vp&output=xml_vast3&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&ad_rule=1&cmsid=11924&vid=cWCkSYdFlU0&cust_params=gmf_format%3Dstd%2Cskip"],
+                                 adTagURL:@"http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=%2F15018773%2Feverything2&"
+       @"ciu_szs=300x250%2C468x60%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&"
+       @"unviewed_position_start=1url=[referrer_url]&correlator=[timestamp]&cmsid=133&"
+       @"vid=10XWSh7W4so&ad_rule=1"],
     ];
   }
 }

--- a/GoogleMediaFrameworkDemo/Podfile
+++ b/GoogleMediaFrameworkDemo/Podfile
@@ -4,4 +4,4 @@ platform :ios, "6.1"
 
 pod "GoogleMediaFramework", :path => "../"
 # Demo app shows how to integrate with the Google IMA SDK, but this is optional.
-pod "GoogleAds-IMA-iOS-SDK", "~> 3.0.beta"
+pod "GoogleAds-IMA-iOS-SDK", "~> 3.0.beta.16"


### PR DESCRIPTION
Updating IMA to beta 16. 

Use https compliant ad tags and media files.

Reuse the adsLoader.