### PR TITLE
Removed CocoaPods install step from Travis build config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: objective-c
 
 before_install:
-  # Cocoapods isn't currently installed by default on
-  # Travis-CI, but may be in the near future.
-  - gem install cocoapods --no-document
   - cd GoogleMediaFrameworkDemo
 
 script:


### PR DESCRIPTION
It looks like Travis now has CocoaPods available, and as such the command to install it fails.