### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-#How to become a contributor and submit patches
+# How to become a contributor and submit patches
 
-##Contributor License Agreements
+## Contributor License Agreements
 
 We'd love to accept your code patches! However, before we can take them, we have to clear a couple of legal hurdles.
 
@@ -11,13 +11,13 @@ Please fill out either the individual or corporate Contributor License Agreement
 
 Follow either of the two links above to access the appropriate CLA and instructions for how to sign and return it. Once we receive it, we'll add you to the official list of contributors and be able to accept your patches.
 
-##Submitting Patches
+## Submitting Patches
 
 - Sign a Contributor License Agreement (see above).
 - Join the [Google Media Framework discussion group](http://groups.google.com/d/forum/google-media-framework).
 - Fork the library, make the changes and send a [pull request](https://help.github.com/articles/using-pull-requests).
 - We will review your patch and add comments if any changes are required. Once any issues are resolved, we'll merge your request!
 
-#If you can't become a contributor
+# If you can't become a contributor
 
 If you can't become a contributor, but wish to share some code that illustrates an issue / shows how an issue may be fixed, then you can attach your changes on the issues page. We will use this code to troubleshoot the issue and fix it, but will not use this code in the library unless the steps to submit patches are done.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#Google Media Framework for iOS
+# Google Media Framework for iOS
 
 [![Build Status](https://travis-ci.org/googleads/google-media-framework-ios.png?branch=master)](https://travis-ci.org/googleads/google-media-framework-ios)
 
-##Introduction
+## Introduction
 The Google Media Framework (GMF) is a lightweight media player designed to make video playback and integration with the Google IMA SDK on iOS easier.
 
 ![Google Media Framework iOS Demo](http://googleads.github.io/google-media-framework-ios/gmf_ios_portrait.png)
 
-##Features
+## Features
 - A simple video player UI for video playback on iOS.
 - Easily integrate the Google IMA SDK to enable advertising on your video content.
 
-##Getting started
+## Getting started
 The easiest way to get started is by using [CocoaPods](http://cocoapods.org).
 
 Create a new single view xcode project, then add the following line to your ```Podfile```:
@@ -68,14 +68,14 @@ The demo app includes the [Google Interactive Media Ads (IMA) SDK](https://devel
 
 If you don't want to use CocoaPods, you should be able to integrate the framework by cloning the project and manually adding the classes and image resources to your project.
 
-##Where do I report issues?
+## Where do I report issues?
 Please report issues on the [issues page](../../issues).
 
-##Support
+## Support
 If you have questions about the framework, you can ask them at http://groups.google.com/d/forum/google-media-framework
 
-##How do I contribute?
+## How do I contribute?
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
-##Requirements
+## Requirements
   - iOS 6.1+


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
